### PR TITLE
fix(clip2file.py): parser: make positional2 argument optional

### DIFF
--- a/src/clip2file/clip2file.py
+++ b/src/clip2file/clip2file.py
@@ -109,8 +109,7 @@ def get_args() -> Args:
 
     parser.add_argument(
         "positional2",
-        #  type="str",
-        nargs="+",
+        nargs="?",
         action="append",
         default=[],
         help="Enter a description of the new files contents.",


### PR DESCRIPTION
fixes #15
